### PR TITLE
Add modifying keys to click

### DIFF
--- a/vimouse.lua
+++ b/vimouse.lua
@@ -47,6 +47,7 @@ return function(tmod, tkey)
     if clicks > 3 then
       clicks = 3
     end
+    e:setFlags(modkeys)
     e:setProperty(eventPropTypes.mouseEventClickState, clicks)
     e:post()
   end


### PR DESCRIPTION
I was unable to do a cmd click, this seemed to fix it. Ctrl click already correctly gave right click, but I believe that was separate at line 73.