### PR TITLE
Post the mouseMoved event when mouse is moved

### DIFF
--- a/vimouse.lua
+++ b/vimouse.lua
@@ -171,6 +171,7 @@ return function(tmod, tkey)
           postEvent(eventTypes.leftMouseDragged, coords, flags, 0)
         else
           hs.mouse.setAbsolutePosition(coords)
+          postEvent(eventTypes.mouseMoved, coords, flags, 0)
         end
       end
     end


### PR DESCRIPTION
Currently, when the mouse is moved, things on the screen will not reflects  to it (something like the hovering event on a button).

It's because the mouseMoved event was not sent.

This PR added the postEvent call that trigger the mouseMoved event, so, from now, when the mouse is moved, it will be recorded as an actual mouse move.

Here's the demo:

**Without the fix:**

![2022-11-15 15 55 56](https://user-images.githubusercontent.com/613943/202049777-4b491260-d7a2-4b6b-8d0e-0e8160c09f87.gif)

**With the fix:**

![2022-11-15 15 53 13](https://user-images.githubusercontent.com/613943/202049476-4066db59-3104-4d99-9bd8-361b88ad5ec8.gif)
